### PR TITLE
fix(annotation): use correct len for original annotation

### DIFF
--- a/pkg/kapp/diff/resource_with_history.go
+++ b/pkg/kapp/diff/resource_with_history.go
@@ -5,6 +5,7 @@ package diff
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/validation"
 	"os"
 
 	ctlres "carvel.dev/kapp/pkg/kapp/resources"
@@ -97,14 +98,10 @@ func (r ResourceWithHistory) RecordLastAppliedResource(appliedChange Change) (ct
 		},
 	}
 
-	const annValMaxLen = 262144
-
 	// kapp deploy should work without adding disable annotation when annotation value max length exceed
 	// (https://github.com/carvel-dev/kapp/issues/410)
-	for _, annVal := range annsMod.KVs {
-		if len(annVal) > annValMaxLen {
-			return nil, false, nil
-		}
+	if err = validation.ValidateAnnotationsSize(annsMod.KVs); err != nil {
+		return nil, false, nil
 	}
 
 	resultRes := r.resource.DeepCopy()


### PR DESCRIPTION
#### What this PR does / why we need it:
The computation for max. length of annotations (256KB) is flawed at the moment as it looks at the length of single values in the map and not the complete map size (which is the actual limitation).

#### Which issue(s) this PR fixes:
Fixes #48

#### Does this PR introduce a user-facing change?
NONE

```release-note
fix: use correct length calculation for original annotation limits
```

#### Additional Notes for your reviewer:

##### Review Checklist:

- [x] Follows the [developer guidelines](https://carvel.dev/shared/docs/latest/development_guidelines/)
- [ ] Relevant tests are added or updated (none exist as of now it seems)
- [ ] Relevant docs in this repo added or updated (bugfix)
- [ ] Relevant carvel.dev docs added or updated in a separate PR and there's
  a link to that PR
- [x] Code is at least as readable and maintainable as it was before this
  change

#### Additional documentation e.g., Proposal, usage docs, etc.:

```docs

```
