### PR TITLE
Return an error instead of panicking on a non-map array element

### DIFF
--- a/pkg/kapp/resources/mod_field_copy.go
+++ b/pkg/kapp/resources/mod_field_copy.go
@@ -120,7 +120,10 @@ func (t FieldCopyMod) apply(obj interface{}, srcObj interface{}, path Path, full
 
 					var srcTypeObj map[string]interface{}
 					if objI < len(srcTypedObj) {
-						srcTypeObj = srcTypedObj[objI].(map[string]interface{})
+						srcTypeObj, ok = srcTypedObj[objI].(map[string]interface{})
+						if !ok {
+							return false, fmt.Errorf("Unexpected non-map found: %T", srcTypedObj[objI])
+						}
 					}
 					updated, err := t.apply(obj, srcTypeObj, path[i+1:], newFullPath, srcs)
 					if err != nil {

--- a/pkg/kapp/resources/mod_field_copy_test.go
+++ b/pkg/kapp/resources/mod_field_copy_test.go
@@ -239,3 +239,34 @@ func (e modFieldCopyExample) Check(t *testing.T) {
 
 	expectEqualsStripped(t, e.Description, string(resultBs), e.Expected)
 }
+
+func TestModFieldCopyNonMapArrayElement(t *testing.T) {
+	// The default config carries allIndexes copy rules, for example
+	// [webhooks, {allIndexes: true}, clientConfig, caBundle], so a source
+	// resource whose array holds a scalar where a map is expected reaches this
+	// path without any custom config.
+	res := ctlres.MustNewResourceFromBytes([]byte(`
+metadata:
+  labels:
+  - {}`))
+
+	ress := map[ctlres.FieldCopyModSource]ctlres.Resource{
+		ctlres.FieldCopyModSourceNew: ctlres.MustNewResourceFromBytes([]byte(`
+metadata:
+  labels:
+  - just-a-string`)),
+	}
+
+	err := ctlres.FieldCopyMod{
+		ResourceMatcher: ctlres.AllMatcher{},
+		Path: ctlres.Path{
+			ctlres.NewPathPartFromString("metadata"),
+			ctlres.NewPathPartFromString("labels"),
+			ctlres.NewPathPartFromIndexAll(),
+			ctlres.NewPathPartFromString("label-key"),
+		},
+		Sources: []ctlres.FieldCopyModSource{ctlres.FieldCopyModSourceNew},
+	}.ApplyFromMultiple(res, ress)
+
+	require.ErrorContains(t, err, "Unexpected non-map found")
+}


### PR DESCRIPTION
In `FieldCopyMod.apply`, the `allIndexes` branch walks the target array and pulls the source element at the same index:

```go
var srcTypeObj map[string]interface{}
if objI < len(srcTypedObj) {
    srcTypeObj = srcTypedObj[objI].(map[string]interface{})
}
```

The assertion has no comma-ok, so a source resource whose array holds a scalar at that position panics:

```
panic: interface conversion: interface {} is string, not map[string]interface {}
```

This is the only unchecked assertion of its kind in the file. The `ArrayIndex.Index` branch and every `MapKey` branch use comma-ok and return `Unexpected non-map found: %T`, so the fix just brings this one in line.

It is reachable without custom config. `FieldCopyMod` implements `type: copy` rebase rules, and the bundled default config ships allIndexes copy rules, for example `[webhooks, {allIndexes: true}, clientConfig, caBundle]` for webhook configurations, so a resource whose array element is a scalar where a map is expected crashes the diff rather than producing an error.

Test added to `mod_field_copy_test.go` as its own function, since the shared `modFieldCopyExample.Check` requires no error. It panics on develop and gets the expected error with the change; `go test ./pkg/kapp/resources/` is green.