### PR TITLE
Do not panic on a manifest whose apiVersion has extra separators

### DIFF
--- a/pkg/kapp/resources/resource.go
+++ b/pkg/kapp/resources/resource.go
@@ -147,14 +147,10 @@ func (r *ResourceImpl) GroupKind() schema.GroupKind {
 }
 
 func (r *ResourceImpl) GroupVersion() schema.GroupVersion {
-	pieces := strings.Split(r.APIVersion(), "/")
-	if len(pieces) > 2 {
-		panic(fmt.Errorf("Expected version to be of format group/version: was %s", r.APIVersion())) // TODO panic
-	}
-	if len(pieces) == 1 {
-		return schema.GroupVersion{Group: "", Version: pieces[0]}
-	}
-	return schema.GroupVersion{Group: pieces[0], Version: pieces[1]}
+	// apiVersion comes straight from the user's manifest, so it may not be
+	// well formed. Use the same parse GroupKind above relies on, which reports
+	// an empty group and version rather than panicking on a malformed value.
+	return r.un.GroupVersionKind().GroupVersion()
 }
 
 func (r *ResourceImpl) Kind() string       { return r.un.GetKind() }

--- a/pkg/kapp/resources/resource_test.go
+++ b/pkg/kapp/resources/resource_test.go
@@ -78,3 +78,31 @@ metadata:
 
 	require.NotContains(t, string(compactBs), "\n", "Expected compact repr to not have newlines")
 }
+
+func TestGroupVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		apiVersion      string
+		expectedGroup   string
+		expectedVersion string
+	}{
+		{"core group", "v1", "", "v1"},
+		{"named group", "apps/v1", "apps", "v1"},
+		{"more separators than a group and a version", "a/b/c", "", ""},
+		{"empty", "", "", ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res := ctlres.MustNewResourceFromBytes([]byte(`
+apiVersion: ` + test.apiVersion + `
+kind: Config
+metadata:
+  name: cfg
+`))
+			gv := res.GroupVersion()
+			require.Equal(t, test.expectedGroup, gv.Group)
+			require.Equal(t, test.expectedVersion, gv.Version)
+		})
+	}
+}


### PR DESCRIPTION
`ResourceImpl.GroupVersion` splits `apiVersion` by hand and panics when there are more than two pieces. The line carries its own `// TODO panic`:

```go
pieces := strings.Split(r.APIVersion(), "/")
if len(pieces) > 2 {
	panic(fmt.Errorf("Expected version to be of format group/version: was %s", r.APIVersion())) // TODO panic
}
```

`apiVersion` is copied straight out of a user manifest, so a file containing `apiVersion: a/b/c` is enough to take kapp down instead of producing a message anyone can act on. It is reached on ordinary paths, including `APIGroup`, the permissions validators and the failing-api-services policy.

`GroupKind`, immediately above it, already delegates to the unstructured helper. That helper parses the same field through `schema.ParseGroupVersion` and falls back to an empty group and version when the value is malformed, so the two methods currently disagree about what a bad `apiVersion` means. This makes `GroupVersion` use the same parse, which removes the panic and leaves the well-formed cases untouched.

Verification: a table test in `pkg/kapp/resources` builds real resources from YAML. The core-group, named-group and empty rows pass either way, and the `a/b/c` row panics on `develop` and passes here. `go test ./pkg/...` output is otherwise unchanged against `develop`, with no failures on either side.
